### PR TITLE
Made thumbnail list responsive 

### DIFF
--- a/docs/_layouts/listing.html
+++ b/docs/_layouts/listing.html
@@ -1,6 +1,7 @@
 <html>
 <head>
 <title>{{ page.title }} | Creative Commons Resource Archive</title>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1" />
 <link rel="stylesheet" type="text/css" href="/style.css" />
 
 
@@ -142,7 +143,7 @@ Creative Commons Resource Archive
 			{% if page.layout == 'resource' %}
 				{% if page.weight == i %}
 					{% unless page.featured %}
-						{% if page.{{paramfilter}} == page.{{paramvalue %}
+						{% if page.paramfilter == page.paramvalue %}
 					{% if page.topic contains topicfilter or topicfilter == null %}
 					{% if page.medium contains mediumfilter or mediumfilter == null %}
 					{% if page.language contains languagefilter or languagefilter == null %}

--- a/docs/style.css
+++ b/docs/style.css
@@ -12,8 +12,10 @@ text-align: center;
 }
 
 #thumbnaillist {
-max-width: 900px;
-min-width: 250px;
+display: flex;
+justify-content: center;
+flex-wrap: wrap;
+width: 100vw;
 margin-left: auto;
 margin-right: auto;
 }
@@ -45,12 +47,17 @@ padding: 10px;
 }
 
 .thumbnailbox {
-width: 200px;
-float: left;
+width: 20vw;
 display: block;
 border-radius: 25px;
 border: 2px solid #C0C0C0;
-margin: 5px;
+margin:15px;
+}
+
+
+
+.thumbnailbox > a{
+  text-decoration: none;
 }
 
 .thumbnailtitle {
@@ -59,8 +66,8 @@ height: 75px;
 }
 
 .thumbnailblurb {
-height: 100px;
-padding: 5px;
+text-align: center;
+padding: 4vh 2vw;
 }
 
 .thumbnail {
@@ -123,3 +130,16 @@ height: 50px;
 background-image: url(/images/cc-green-210.gif);
 margin-left: 100px;
 }
+
+@media  screen and (max-width: 1100px) {
+  .thumbnailbox{
+    width: 40vw;
+  }
+}
+
+@media  screen and (max-width: 600px) {
+  .thumbnailbox {
+    width: 60vw;
+  }
+}
+


### PR DESCRIPTION
## Fixes
Fixes #25  by @tinniaru3005
Fixes #26 by @tinniaru3005

## Description
Earlier the page used to scale down if screen size reduced. Fixed that by changing viewport tag.
Also the number of boxes and there size used to be static on reducing screen size making them unreadable on smaller screens , It now shows 4 boxes on large screens, 2 on medium sized and 1 on mobile sized screens.


## Tests
Run the site and check the responsiveness on the home page

## Screenshots

<img width="553" alt="Screenshot 2023-02-24 at 11 38 27 AM" src="https://user-images.githubusercontent.com/104081946/221105212-f803f965-1507-46fb-8b8d-d8e31b3fb199.png">

<img width="558" alt="Screenshot 2023-02-24 at 11 38 40 AM" src="https://user-images.githubusercontent.com/104081946/221105195-ed237db4-1314-47bf-8ac0-c680c3f977b5.png">

<img width="549" alt="Screenshot 2023-02-24 at 11 38 48 AM" src="https://user-images.githubusercontent.com/104081946/221105173-990115d5-700c-4e56-9471-84cd032db2fb.png">


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
