### PR TITLE
Fixed the whole header working as a link [bug]. 

### DIFF
--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -1,1 +1,1 @@
-<a href="//creativecommons.org/"><div id="bannercc"></div></a>
+<a href="https://resources.creativecommons.org/"><img src="/images/cc-green-210.gif" id="bannercc"></img></a>

--- a/docs/style.css
+++ b/docs/style.css
@@ -120,6 +120,5 @@ background-color: #627d0f;
 #bannercc {
 width: 210px;
 height: 50px;
-background-image: url(/images/cc-green-210.gif);
 margin-left: 100px;
 }


### PR DESCRIPTION
…ink with the resources.creativecommons website.

## Fixes

Fixes #70 by @Src0p 

## Description
Div was enclosed in the hyperlink , but in the ideal situation only logo should do this.
So removed the div and replaced it with Img tag and instead of placing image with css , used the src attribute.


## Screenshots
Before: 
![beforeHeader](https://user-images.githubusercontent.com/97759886/224678988-e550618f-fec2-420f-bfbd-705360ee7d14.png)

Now : 
![afterHeader](https://user-images.githubusercontent.com/97759886/224679118-9473e2be-f108-48c2-9cbe-531c0b05b778.png)


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [ ] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
