### PR TITLE
Remove link from resource images

### DIFF
--- a/docs/_layouts/resource.html
+++ b/docs/_layouts/resource.html
@@ -1,116 +1,145 @@
 <html lang="en">
+
 <head>
-<title>{{ page.title }} | Creative Commons</title>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+	<title>{{ page.title }} | Creative Commons</title>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<script>
+		(function (i, s, o, g, r, a, m) {
+			i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+				(i[r].q = i[r].q || []).push(arguments)
+			}, i[r].l = 1 * new Date(); a = s.createElement(o),
+				m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+		})(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
 
-  ga('create', 'UA-2010376-29', 'auto');
-  ga('send', 'pageview');
+		ga('create', 'UA-2010376-29', 'auto');
+		ga('send', 'pageview');
 
-</script>
+	</script>
 
-<link rel="stylesheet" type="text/css" href="/style.css" />
+	<link rel="stylesheet" type="text/css" href="/style.css" />
 	{% if page.downloadurl %}
-		{% if page.repourl %}
-			<style>#downloadbuttonholder { width: 440px; }</style>
-		{% else %}
-			<style>#downloadbuttonholder { width: 220px; }</style>
-		{% endif %}
+	{% if page.repourl %}
+	<style>
+		#downloadbuttonholder {
+			width: 440px;
+		}
+	</style>
+	{% else %}
+	<style>
+		#downloadbuttonholder {
+			width: 220px;
+		}
+	</style>
+	{% endif %}
 	{% elsif page.repourl %}
-		<style>#downloadbuttonholder { width: 220px; }</style>
+	<style>
+		#downloadbuttonholder {
+			width: 220px;
+		}
+	</style>
 	{% endif %}
 
 	{% if page.repourl contains 'layervault.com' %}
-		<style>.downloadbutton.repository {background-image: url("/images/layervault.png")}</style>
+	<style>
+		.downloadbutton.repository {
+			background-image: url("/images/layervault.png")
+		}
+	</style>
 	{% endif %}
-	
+
 	{% if page.repourl contains 'github.com' %}
-		<style>.downloadbutton.repository {background-image: url("/images/github.png")}</style>
+	<style>
+		.downloadbutton.repository {
+			background-image: url("/images/github.png")
+		}
+	</style>
 	{% endif %}
 
 </head>
+
 <body>
 
-{% include header.html %}
+	{% include header.html %}
 
-<h1><a href="/">Creative Commons Resource Archive</a></h1>
+	<h1><a href="/">Creative Commons Resource Archive</a></h1>
 
-<h2 style="text-align: center; ">{{ page.title }}</h2>
+	<h2 style="text-align: center; ">{{ page.title }}</h2>
 
 	{% if page.embed %}
 	<div align="center">{{ page.embed }}</div>
 	{% else %}
-	{% if page.downloadurl %}
-		<a href="{{ page.downloadurl }}" target="_blank">
-	{% endif %}
-
 	{% if page.image-full %}
-		<div id="preview" style="background-image: url({{page.image-full}})"></div>
+	<div id="preview" style="background-image: url({{page.image-full}})"></div>
 	{% else %}
-		<div id="preview"></div>
+	<div id="preview"></div>
+	{% endif %}
 	{% endif %}
 
-	{% if page.downloadurl %}
-		</a>
-	{% endif %}
-	{% endif %}
 	{% if page.downloadurl or page.repourl %}
-<div id="downloadbuttonholder">
-	{% endif %}
-
-	{% if page.downloadurl %}
-		<a href="{{ page.downloadurl }}" target="_blank">
-		<div class="downloadbutton">
-		{% if page.medium == "website" or page.medium == "course" %} 
-			<p>Visit</p>
-		{% else %}
-			<p>Download</p>
+	<div id="downloadbuttonholder">
 		{% endif %}
-		</div>
+
+		{% if page.downloadurl %}
+		<a href="{{ page.downloadurl }}" target="_blank">
+			<div class="downloadbutton">
+				{% if page.medium == "website" or page.medium == "course" %}
+				<p>Visit</p>
+				{% else %}
+				<p>Download</p>
+				{% endif %}
+			</div>
 		</a>
+		{% endif %}
+
+
+		{% if page.downloadurl or page.repourl %}
+	</div>
 	{% endif %}
 
+	<div style="clear: both;"></div>
 
-	{% if page.downloadurl or page.repourl %}
-		</div>
-	{% endif %}
-
-<div style="clear: both;"></div>	
-
-<div id="longdescription">
-{{content}}
-</div>
+	<div id="longdescription">
+		{{content}}
+	</div>
 
 
 	{% if page.license %}
-	
-	
-		{% if page.license == 'CC0' %}
-			<p align="center"><a rel="license" href="http://creativecommons.org/publicdomain/zero/1.0/"><img src="http://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0" /></a>
-  <br />
-  To the extent possible under law, <span property="dct:publisher">{{ page.author }}</span> has waived all copyright and related or neighboring rights to <a href="{{ page.downloadurl}}"dct:title">{{ page.title }}</a>.</p>
-		
-		{% else %}
-			
-		<p align="center"><a rel="license" href="http://creativecommons.org/licenses/{{ page.license | remove: 'CC ' | downcase | replace: ' ', '/' }}/"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/{{ page.license | remove: 'CC ' | downcase | replace: ' ', '/' }}/88x31.png" /></a><br />
 
-{% if page.downloadurl %}<a href="{{ page.downloadurl }}" rel="cc:attributionURL">{% endif %}<span xmlns:dct="http://purl.org/dc/terms/" property="dct:title">{{ page.title }}</span>{% if page.downloadurl %}</a>{% endif %}{% if page.author %} by <span xmlns:cc="http://creativecommons.org/ns#" property="cc:attributionName" >{{ page.author }}</span>{% endif %} is licensed under <a rel="license" href="http://creativecommons.org/licenses/{{ page.license | remove: 'CC ' | downcase | replace: ' ', '/' }}/">{{ page.license }}</a>.</p>
 
-		{% endif %}
+	{% if page.license == 'CC0' %}
+	<p align="center"><a rel="license" href="http://creativecommons.org/publicdomain/zero/1.0/"><img
+				src="http://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0" /></a>
+		<br />
+		To the extent possible under law, <span property="dct:publisher">{{ page.author }}</span> has waived all
+		copyright and related or neighboring rights to <a href="{{ page.downloadurl}}" dct:title">{{ page.title }}</a>.
+	</p>
+
+	{% else %}
+
+	<p align="center"><a rel="license"
+			href="http://creativecommons.org/licenses/{{ page.license | remove: 'CC ' | downcase | replace: ' ', '/' }}/"><img
+				alt="Creative Commons License" style="border-width:0"
+				src="http://i.creativecommons.org/l/{{ page.license | remove: 'CC ' | downcase | replace: ' ', '/' }}/88x31.png" /></a><br />
+
+		{% if page.downloadurl %}<a href="{{ page.downloadurl }}" rel="cc:attributionURL">{% endif %}<span
+				xmlns:dct="http://purl.org/dc/terms/" property="dct:title">{{ page.title }}</span>{% if page.downloadurl
+			%}</a>{% endif %}{% if page.author %} by <span xmlns:cc="http://creativecommons.org/ns#"
+			property="cc:attributionName">{{ page.author }}</span>{% endif %} is licensed under <a rel="license"
+			href="http://creativecommons.org/licenses/{{ page.license | remove: 'CC ' | downcase | replace: ' ', '/' }}/">{{
+			page.license }}</a>.</p>
+
+	{% endif %}
 	{% endif %}
 
 
 </body>
 <script>
 	const globalHeader = document.getElementById("global-header");
-    const handleExplore = (event) => {
-        globalHeader.classList.toggle("active");
-        event.preventDefault();
-    }
+	const handleExplore = (event) => {
+		globalHeader.classList.toggle("active");
+		event.preventDefault();
+	}
 </script>
+
 </html>


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
Fixes #197  by @Xaid-vfx 

## Description
<!-- Concisely describe what the pull request does. -->
Resource images and whitespace no longer act as links. Also, improved the formatting of the code.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->
Removed the anchor tag around the resource image div to prevent unintended navigation.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete this section entirely. -->
The cursor does not change to pointer, indicating there is no link in the area
![image](https://github.com/creativecommons/cc-resource-archive/assets/122149755/19cc6806-6a90-4e78-9fa3-e2bee03e71e6)


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [ ] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main` or `master`).
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
