### PR TITLE
Explore CC header's sliding behaviour and stylings have been changed

### DIFF
--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -15,19 +15,19 @@
                 <a id="global-header-link" href="https://network.creativecommons.org/" target="_blank" rel="noopener noreferrer"><span id="global-header-title">Global Network</span><br>
                     <p>Join a global community working to strengthen the Commons</p>
                 </a>
-                <a id="global-header-link" href="https://certificate.creativecommons.org/" target="_blank" rel="noopener noreferrer"><span id="global-header-title">Certificate program</span><br>
+                <a id="global-header-link" href="https://certificate.creativecommons.org/" target="_blank" rel="noopener noreferrer"><span id="global-header-title">Certificate</span><br>
                     <p>Become an expert in creating and engaging with openly licensed materials</p>
                 </a>
                 <a id="global-header-link" href="https://summit.creativecommons.org/" target="_blank" rel="noopener noreferrer"><span id="global-header-title">Global Summit</span><br>
                     <p>Attend our annual event, promoting the power of open licensing</p>
                 </a>
-                <a id="global-header-link" href="https://chooser-beta.creativecommons.org/" target="_blank" rel="noopener noreferrer"><span id="global-header-title">License Chooser</span><br>
+                <a id="global-header-link" href="https://chooser-beta.creativecommons.org/" target="_blank" rel="noopener noreferrer"><span id="global-header-title">Chooser</span><br>
                     <p>Get help choosing the appropriate license for your work</p>
                 </a>
-                <a id="global-header-link" href="https://search.creativecommons.org/" target="_blank" rel="noopener noreferrer"><span id="global-header-title">CC Search</span><br>
-                    <p>Find openly licensed material for creative and educational reuse</p>
+                <a id="global-header-link" href="https://search.creativecommons.org/" target="_blank" rel="noopener noreferrer"><span id="global-header-title">Search Portal</span><br>
+                    <p>Find engines to search openly licensed material for creative and educational reuse</p>
                 </a>
-                <a id="global-header-link" href="https://opensource.creativecommons.org/" target="_blank" rel="noopener noreferrer"><span id="global-header-title">CC Open Source</span><br>
+                <a id="global-header-link" href="https://opensource.creativecommons.org/" target="_blank" rel="noopener noreferrer"><span id="global-header-title">Open Source</span><br>
                     <p>Help us build products that maximize creativity and innovation</p>
                 </a>
             </div>

--- a/docs/style.css
+++ b/docs/style.css
@@ -13,26 +13,26 @@ padding: 30px 0 0;
 
 #global-header {
     font-family: 'Source Sans Pro', sans-serif;
-    position: absolute;
-    top: 0;
+    position: relative;
+    top: -30px;
     background-color: #000000;
     color: #ffffff;
     padding: 2.5% 7.5% 2.5%;
-    margin-bottom: -50px;
+    margin-bottom: -78px;
     transform: translateY(-100%);
-    transition: transform 1.4s ease, margin-bottom 1.4s ease;
+    transition: transform 0s ease, margin-bottom 0s ease;
 } 
 
 #global-header.active {
-    margin-bottom: 50px;
+    margin-bottom: 0px;
     transform: translateY(0);
-    transition: transform 0.7s ease, margin-bottom 0.7s ease;
+    transition: transform 0s ease, margin-bottom 0s ease;
 }
 
 #global-header .container{
     max-height: 0;
     overflow: hidden;
-    transition: max-height 1s ease;
+    transition: max-height 0s ease;
 }
 
 #global-header.active .container{
@@ -44,14 +44,15 @@ padding: 30px 0 0;
     color: #ffffff;
     position: absolute;
     bottom: -2rem;
-    right: 10%;
-    padding: 5px 5px 10px;
+    right: 5%;
+    padding: 16px 10px 6px;
     border: none;
     border-radius: 0 0 5px 5px;
+    font-size: 0.8em;
 }
 
 #global-header-btn:hover {
-    text-decoration: underline;
+    text-decoration: none;
     text-decoration-color: white;
     cursor: pointer;
 }
@@ -79,6 +80,7 @@ padding: 30px 0 0;
     background-color: #FBD43C;
     color: #000000;
     font-weight: bold;
+    border-radius: 3px;
 }
 
 #cc-heart{
@@ -99,17 +101,12 @@ padding: 30px 0 0;
     min-width: fit-content;
 }
 
-#global-header-link:hover {
-    text-decoration: underline;
-}
-
 #global-header-title {
     color: #05ACC7;
     font-weight: bold;
 }
 
 #global-header-link:hover #global-header-title {
-    text-decoration: underline;
     text-decoration-color: #05ACC7;
 }
 


### PR DESCRIPTION
The Explore CC header do not slides upon other elements anymore. Rather when it slides down, other elements also slides down.

## Fixes
Fixes #207 by @FZehra1512

## Description
Now the Explore CC header do not slides upon other elements because its various CSS properties are changed e.g. position, transition etc. The PR also removed underline effects on hover, from header button and links and also changes the name of header links just for uniformity with [creativecommons.org](https://creativecommons.org/) Explore CC header.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete this section entirely. -->
**Problem**

![image](https://github.com/creativecommons/cc-resource-archive/assets/142977761/f35be733-24ad-49db-a250-ded9a0380a2c)

**Solution** 

![image](https://github.com/creativecommons/cc-resource-archive/assets/142977761/b9244b96-0a43-4912-8bc5-a082a4a39186)


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
