### PR TITLE
ADDED: [Feature] Logo should navigate to CC resources' site instead of creativecommons.org home page

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -270,6 +270,7 @@ GEM
 PLATFORMS
   aarch64-linux
   arm64-darwin-23
+  x86_64-linux
   x86_64-linux-musl
 
 DEPENDENCIES

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -37,6 +37,12 @@
 
 <!-- Main Content -->
 
-<a href="//creativecommons.org/">
-    <div id="bannercc"></div>
-</a>
+
+<div class="Header">
+    
+        <a href="/">
+            <div id="bannercc"></div>
+        </a>
+
+        <span class="subheader">Resources Archive</span>    
+<</div>

--- a/docs/style.css
+++ b/docs/style.css
@@ -252,14 +252,25 @@ display: none;
 .resourcenav.resourcenavstatic {
 display: block;
 }
-
+.Header, .Header a {
+    padding-top: 10;
+    text-align: left;
+}
 #bannercc {
 width: 210px;
 height: 50px;
 background-image: url(/images/cc-green-210.gif);
 margin-left: 100px;
 }
-
+.subheader {
+    display: block;
+    font-family: "Akzidenz Grotesk", sans-serif;
+    font-size: 10px;
+    font-weight: bold;
+    text-transform: uppercase;
+    margin-left: 150px;
+    letter-spacing: 3px;
+}
 footer a {
     color: var(--vocabulary-brand-color-turquoise);
 }


### PR DESCRIPTION
## Fixes
Fixes #210  by @Sana-Maryam90

## Description
CreativeCommons Resources Archive logo will now navigate to its own `home page` [resources.creativecommons.org](https://resources.creativecommons.org/) instead of navigating to other website [creativecommons.org](https://creativecommons.org/). Keeping the Color scheme already being followed.


## Screenshots


https://github.com/creativecommons/cc-resource-archive/assets/130001453/5f3a6839-c491-477f-b381-e68a40a13c7e


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
