### PR TITLE
Fixed overlapping text on languages list on home page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -25,7 +25,7 @@ title: Home
 
 <div class="resourcenav resourcenavstatic">
 <h2>Language</h2>
-<ul style="columns: 2;">
+<ul style="columns: 2; column-gap: 35px;">
 	{% for language in site.data.languages %}
 		<li><a href="/all?&language={{ language.string }}">{{ language.name}}</a></li>
 	{% endfor %}


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
Fixes #223 by @praveen-rikhari

## Description
<!-- Concisely describe what the pull request does. -->
Resolved overlapping issue in the Languages section on the home page. The Armenian and Russian language list items were previously overlapping each other, affecting readability. This PR fixes the layout to ensure proper spacing and alignment between the languages. Users can now view the Languages section without any overlapping text.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->
Implemented inline styles on the `<ul>` tag, including `column-gap: 35px;`, alongside existing `columns: 2;`, to address the overlapping issue in the Languages section. This adjustment ensures proper spacing and readability.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete this section entirely. -->
#### Before :
![Screenshot from 2024-03-19 17-42-13](https://github.com/creativecommons/cc-resource-archive/assets/84331681/580a77d7-6dac-4fee-b981-f87f3e41f72f)

#### After :
![Screenshot from 2024-03-21 16-49-08](https://github.com/creativecommons/cc-resource-archive/assets/84331681/f86fa119-ffe9-474e-9f11-9adde7d75f2c)


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
