### PR TITLE
[Fixed]: Added the Explore CC button in the submit page

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -270,6 +270,7 @@ GEM
 PLATFORMS
   aarch64-linux
   arm64-darwin-23
+  x86_64-linux
   x86_64-linux-musl
 
 DEPENDENCIES

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -2,9 +2,9 @@
 <!-- CC Global Header -->
 
 <div class="global-header" id="global-header">
-    <a id="global-header-btn" onclick="handleExplore()">Explore CC</a>
+    <a id="global-header-btn" onclick="handleExplore()" href="https://www.creativecommons.org">Explore CC</a>
     <div class="container">
-        <a href="https://www.creativecommons.org"><img id="cc-main" src="../images/assets/cc-main.svg" alt="Creative Commons"></a>
+        <!-- <a href="https://www.creativecommons.org"><img id="cc-main" src="../images/assets/cc-main.svg" alt="Creative Commons"></a> -->
         <div id="global-header-content">
             <div id="global-header-head">
                 <h3>OUR WORK RELIES ON YOU!</h3>
@@ -37,6 +37,9 @@
 
 <!-- Main Content -->
 
-<a href="//creativecommons.org/">
-    <div id="bannercc"></div>
-</a>
+<div id="bannercc" onclick="redirectToLink()" style="cursor: pointer;"></div>
+<script>
+    function redirectToLink() {
+        window.location.href = "//creativecommons.org/"
+    }
+</script>

--- a/docs/submission.html
+++ b/docs/submission.html
@@ -25,7 +25,7 @@ permalink: /submit/
 </head>
 <body>
 
-	<a href="//creativecommons.org/"><div id="bannercc"></div></a>
+  {% include header.html %}
 
 
 <div style="text-align: center; ">


### PR DESCRIPTION
## Fixes
Fixes #229 by @Cappybara12 and fixes #225 by @praveen-rikhari
- #229
- #225

## Description
Added the Explore CC button to the submit page and, resolved the previous issue of the whole navbar redirecting to creativecommons.org upon clicking.

- Add "Explore CC" Button to Submit Page
  - Description: Incorporate an "Explore CC" button onto the submit page.
  - Objective: To make all the webpages look similar and even.
  
- Fix Navbar Redirection Issue
  - Description: Address the problem of the navbar unintentionally redirecting users to creativecommons.org upon clicking.
  - Objective: Ensure smooth navigation for users without unintended redirections.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
- Test the functionality of the "Explore CC" button to ensure it redirects users to the intended Creative Commons resources.
- Click on the navbar elements to confirm that they no longer redirect users to creativecommons.org unintentionally.
- Ensure that the changes are compatible with different browsers and devices.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete this section entirely. -->

https://github.com/creativecommons/cc-resource-archive/assets/118703472/0c79d450-aaa5-44b3-9c31-31c553079371



## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>