### PR TITLE
Added 'Explore CC' Button on submit Page

### DIFF
--- a/docs/submission.html
+++ b/docs/submission.html
@@ -25,7 +25,7 @@ permalink: /submit/
 </head>
 <body>
 
-	<a href="//creativecommons.org/"><div id="bannercc"></div></a>
+  {% include header.html %}
 
 
 <div style="text-align: center; ">
@@ -39,6 +39,13 @@ permalink: /submit/
 </div>
 
 </body>
+<script>
+	const globalHeader = document.getElementById("global-header");
+    const handleExplore = (event) => {
+        globalHeader.classList.toggle("active");
+        event.preventDefault();
+    }
+</script>
 </html>
 
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
Fixes #225 by @praveen-rikhari
- As noted in issue #225, the submit page currently lacks the "Explore CC" button, which is present on most other pages. 
- #225

## Description
<!-- Concisely describe what the pull request does. -->
To address this, I've added the "Explore CC" button to the header on the submit page. 

## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->
1. Included {% include header.html %} within the <body> tag of the submission.html file. This action incorporates the global header, which contains the "Explore CC" button.
2. Added a JavaScript snippet to handle the functionality of the "Explore CC" button.


## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete this section entirely. -->
Problem: Absence of the "Explore CC" button
<img width="1512" alt="Screenshot 2024-03-23 at 22 29 04" src="https://github.com/creativecommons/cc-resource-archive/assets/118508667/cc396cfd-a687-4ee0-ae63-c4d799ad6433">
Solution: Added the "Explore CC" button
<img width="1512" alt="Screenshot 2024-03-23 at 22 33 44" src="https://github.com/creativecommons/cc-resource-archive/assets/118508667/b587ceb4-0e2c-4845-9020-2d9cb62a1584">
The button is clickable and links to the content of Creative Commons.
<img width="1512" alt="Screenshot 2024-03-23 at 22 26 53" src="https://github.com/creativecommons/cc-resource-archive/assets/118508667/b3986937-b12d-45fd-aefa-4bbad6852b2f">


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
