### PR TITLE
Make docker compose build paths explicit 

### DIFF
--- a/dev/jekyll/Dockerfile
+++ b/dev/jekyll/Dockerfile
@@ -32,7 +32,7 @@ RUN gem install bundler
 WORKDIR /srv/jekyll
 
 # Copy Gemfile and Gemfile.lock
-COPY Gemfile Gemfile.lock ./
+COPY dev/jekyll/Gemfile dev/jekyll/Gemfile.lock ./
 
 #Install site dependencies
 RUN bundle install

--- a/dev/jekyll/Dockerfile
+++ b/dev/jekyll/Dockerfile
@@ -20,10 +20,11 @@ RUN apt-config dump \
 | tee /etc/apt/apt.conf.d/99no-recommends-no-suggests
 
 # Resynchronize the package index
-RUN apt-get update
-
-# Install system dependencies
-RUN apt-get install -y build-essential git
+# https://docs.docker.com/build/building/best-practices/#apt-get
+RUN apt-get update && apt-get install -y \
+        build-essential \
+        git \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install Ruby dependencies
 RUN gem install bundler
@@ -32,7 +33,7 @@ RUN gem install bundler
 WORKDIR /srv/jekyll
 
 # Copy Gemfile and Gemfile.lock
-COPY dev/jekyll/Gemfile dev/jekyll/Gemfile.lock ./
+COPY docs/Gemfile docs/Gemfile.lock ./
 
 #Install site dependencies
 RUN bundle install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,9 @@
 services:
 
   jekyll:
-    build: dev/jekyll
+    build:
+      context: dev/jekyll
+      dockerfile: dev/jekyll/Dockerfile
     container_name: jekyll-cc-resource-archive
     ports:
       - '4000:4000'
@@ -16,7 +18,9 @@ services:
   # Example commands using this service:
   #   docker compose run node prettier --write docs/index.html
   node:
-    build: dev/node
+    build:
+      context: dev/node
+      dockerfile: dev/node/Dockerfile
     container_name: node-cc-resource-archive
     volumes:
       # Mount repository to working directory

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 
   jekyll:
     build:
-      context: dev/jekyll
+      context: .
       dockerfile: dev/jekyll/Dockerfile
     container_name: jekyll-cc-resource-archive
     ports:
@@ -19,8 +19,8 @@ services:
   #   docker compose run node prettier --write docs/index.html
   node:
     build:
-      context: dev/node
-      dockerfile: dev/node/Dockerfile
+      context: .
+      dockerfile: dev/jekyll/Dockerfile
     container_name: node-cc-resource-archive
     volumes:
       # Mount repository to working directory


### PR DESCRIPTION
## Fixes
- Fixes #276 by @Murdock9803

## Description
- Make docker compose build paths explicit and aligned with the assumptions that appear to be present on Linux and Windows versions of Docker
- Avoid reliance on symlinks
- Update apt-get use per best practices

## Technical details
- [Compose Build Specification | Docker Docs](https://docs.docker.com/compose/compose-file/build/)

## Tests
```shell
docker compose build --no-cache
```
```shell
docker compose up
```
- ✅ Linux verified by @possumbilities
- ✅ macOS verified by @TimidRobot
- ✅ Windows 11 verified by @TimidRobot
  - WSL version: 2.1.5.0
  - Linux version: Debian
  - Windows version: 10.0.22631.3737
  - Docker version: 26.1.1

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
