### PR TITLE
Improves the user interface for resource cards and makes them responsive

### DIFF
--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -23,15 +23,15 @@ h1 {
 /* Styles for listing.html resource thumbnail cards */
 #thumbnaillist {
   display: grid;
-    grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
-    margin: 4em 0 8em;
-    padding: 4em var(--vocabulary-page-edges-space);;
-    gap: 5%;
-    box-sizing: border-box;
+  grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
+  margin: 4em 0 8em;
+  padding: 4em var(--vocabulary-page-edges-space);
+  gap: 5%;
+  box-sizing: border-box;
 
-    width:100%;
-    height: fit-content;
-    background: var(--vocabulary-neutral-color-lighter-gray);
+  width: 100%;
+  height: fit-content;
+  background: var(--vocabulary-neutral-color-lighter-gray);
 }
 
 .thumbnailbox {
@@ -50,13 +50,13 @@ h1 {
 }
 
 .thumbnailtitle {
-    font-family:"Roboto Condensed";
-      font-style: normal;
-      font-weight: 700;
-    font-size: 1.5vw;
-    color: var(--vocabulary-brand-color-dark-tomato);
-    --underline-background-color: var(--vocabulary-neutral-color-lighter-gray);
-    --underline-color: var(--vocabulary-brand-color-dark-tomato);
+  font-family: "Roboto Condensed";
+  font-style: normal;
+  font-weight: 700;
+  font-size: 1.5vw;
+  color: var(--vocabulary-brand-color-dark-tomato);
+  --underline-background-color: var(--vocabulary-neutral-color-lighter-gray);
+  --underline-color: var(--vocabulary-brand-color-dark-tomato);
 }
 
 .thumbnailblurb {

--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -45,6 +45,7 @@ h1 {
   width: 100%;
   height: fit-content;
   background: var(--vocabulary-neutral-color-lighter-gray);
+  grid-auto-rows: minmax(100px, auto); /* Adjust this value as needed */
 }
 
 .thumbnailbox {

--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -17,7 +17,6 @@ header {
   width: 100%;
 }
 
-
 /* Styles common for all the pages*/
 main {
   width: 100%;
@@ -32,7 +31,6 @@ main a {
 h1 {
   text-align: center;
 }
-
 
 /* Styles for listing.html resource thumbnail cards */
 #thumbnaillist {
@@ -77,7 +75,6 @@ h1 {
   font-weight: 400;
 }
 
-
 /* Styles For index.html and all.html */
 #resourcenavbar {
   height: fit-content;
@@ -101,7 +98,6 @@ h1 {
   height: 50px;
   margin-left: 100px;
 }
-
 
 /* Styles For resource.html */
 #preview {
@@ -149,9 +145,7 @@ h1 {
   color: white;
 }
 
-
 /* Styles for submission.html */
-
 
 /* Styles For footer.html */
 footer {
@@ -165,7 +159,6 @@ footer a {
 footer .donate a {
   color: #000;
 }
-
 
 /* Media Queries for responsiveness */
 @media screen and (max-width: 600px) {

--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -31,7 +31,6 @@ h1 {
   padding: 4em var(--vocabulary-page-edges-space);
   gap: 5%;
   box-sizing: border-box;
-
   width: 100%;
   height: fit-content;
   background: var(--vocabulary-neutral-color-lighter-gray);
@@ -39,7 +38,6 @@ h1 {
 
 .thumbnailbox {
   grid-column: span 3;
-  border: 2px solid black;
 }
 
 .thumbnailLink {

--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -43,7 +43,8 @@ h1 {
   width: 100%;
   height: fit-content;
   background: var(--vocabulary-neutral-color-lighter-gray);
-  grid-auto-rows: minmax(100px, auto); /* Adjust this value as needed */
+  grid-auto-rows: minmax(100px, auto);
+  list-style: none;
 }
 
 .thumbnailbox {

--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -163,61 +163,61 @@ footer .donate a {
 /* Media Queries for responsiveness */
 @media screen and (max-width: 1024px) {
   #thumbnaillist {
-      gap: 6vw 5%;
-      padding: 4em 7vw 8em;
+    gap: 6vw 5%;
+    padding: 4em 7vw 8em;
   }
 
   .thumbnailbox {
-      grid-column: span 4;
+    grid-column: span 4;
   }
 
   .thumbnailtitle {
-      font-size: 2.4vw;
+    font-size: 2.4vw;
   }
-    
+
   .thumbnailblurb {
-      font-size: 1.7vw;
+    font-size: 1.7vw;
   }
 }
 
 @media screen and (max-width: 600px) {
   #thumbnaillist {
-      gap: 12vw 7%;
-      padding: 4em 6vw 8em;
+    gap: 12vw 7%;
+    padding: 4em 6vw 8em;
   }
 
   .thumbnailbox {
-      grid-column: span 6;
+    grid-column: span 6;
   }
 
   .thumbnailtitle {
-      font-size: 3.5vw;
+    font-size: 3.5vw;
   }
-    
+
   .thumbnailblurb {
-      font-size: 2.5vw;
+    font-size: 2.5vw;
   }
 }
 
 @media screen and (max-width: 480px) {
   #thumbnaillist {
-      gap: 35vw 5%;
-      padding: 4em 6vw 8em;
+    gap: 35vw 5%;
+    padding: 4em 6vw 8em;
   }
 
   .thumbnailbox {
-      grid-column: span 12;
+    grid-column: span 12;
   }
 
   .thumbnailtitle {
-      font-size: 6.5vw;
+    font-size: 6.5vw;
   }
-    
+
   .thumbnailblurb {
-      font-size: 5vw;
+    font-size: 5vw;
   }
 
   #resourcenavbar {
-      flex-direction: column;
+    flex-direction: column;
   }
 }

--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -10,9 +10,13 @@ body {
 }
 
 /* Styles for listing.html and submission.html*/
-.main-content a {
-  color: #40ae49;
-  cursor: pointer;
+main {
+  width: 100%;
+}
+
+main a {
+cursor: pointer;
+height: fit-content;
 }
 
 h1 {

--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -2,7 +2,6 @@
 @import "/_assets/vocabulary/css/vocabulary.css" layer(vocabulary);
 
 /* CSS for All Pages */
-
 body {
   font-family: sans-serif;
   margin: 0;
@@ -15,6 +14,10 @@ header {
 }
 
 /* Styles common for all the pages*/
+body.listing-page {
+  box-sizing: border-box;
+}
+
 main {
   width: 100%;
   padding: 0 0;
@@ -147,6 +150,7 @@ h1 {
 
 /* Styles For footer.html */
 footer {
+  box-sizing: border-box;
   width: 100%;
 }
 
@@ -195,6 +199,10 @@ footer .donate a {
   .thumbnailblurb {
     font-size: 2.5vw;
   }
+
+  #resourcenavbar {
+    flex-direction: column;
+  }
 }
 
 @media screen and (max-width: 480px) {
@@ -213,9 +221,5 @@ footer .donate a {
 
   .thumbnailblurb {
     font-size: 5vw;
-  }
-
-  #resourcenavbar {
-    flex-direction: column;
   }
 }

--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -2,11 +2,19 @@
 @import "/_assets/vocabulary/css/vocabulary.css" layer(vocabulary);
 
 /* CSS for All Pages */
+* {
+  box-sizing: border-box;
+}
+
 body {
   font-family: sans-serif;
   margin: 0;
   width: 100%;
   padding: 0 0 0;
+}
+
+header {
+  width: 100%;
 }
 
 

--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -37,8 +37,8 @@ h1 {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
   margin: 4em 0 0;
-  padding: 4em var(--vocabulary-page-edges-space) 8em;
-  gap: 5%;
+  padding: 4em 10vw 8em;
+  gap: 10% 5%;
   box-sizing: border-box;
   width: 100%;
   height: fit-content;

--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -37,7 +37,7 @@ h1 {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
   margin: 4em 0 0;
-  padding: 4em 10vw 16em;
+  padding: 4em var(--vocabulary-page-edges-space) 16em;
   gap: 10% 5%;
   box-sizing: border-box;
   width: 100%;
@@ -166,7 +166,7 @@ footer .donate a {
 @media screen and (max-width: 1024px) {
   #thumbnaillist {
     gap: 6vw 5%;
-    padding: 4em 7vw 8em;
+    padding: 4em var(--vocabulary-page-edges-space) 8em;
   }
 
   .thumbnailbox {
@@ -185,7 +185,7 @@ footer .donate a {
 @media screen and (max-width: 600px) {
   #thumbnaillist {
     gap: 12vw 7%;
-    padding: 4em 6vw 8em;
+    padding: 4em var(--vocabulary-page-edges-space) 8em;
   }
 
   .thumbnailbox {
@@ -208,7 +208,7 @@ footer .donate a {
 @media screen and (max-width: 480px) {
   #thumbnaillist {
     gap: 35vw 5%;
-    padding: 4em 6vw 8em;
+    padding: 4em var(--vocabulary-page-edges-space) 8em;
   }
 
   .thumbnailbox {

--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -43,6 +43,12 @@ h1 {
   text-decoration: none;
 }
 
+.thumbnail {
+  width: 100%;
+  aspect-ratio: 200/150;
+  margin: 0 auto;
+}
+
 .thumbnailtitle {
   text-align: center;
   height: 75px;
@@ -51,12 +57,6 @@ h1 {
 .thumbnailblurb {
   height: 100px;
   padding: 5px;
-}
-
-.thumbnail {
-  width: 200px;
-  height: 150px;
-  margin: 0 auto;
 }
 
 /* Styles For resource.html */

--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -181,7 +181,43 @@ footer .donate a {
 }
 
 @media screen and (max-width: 600px) {
+  #thumbnaillist {
+      gap: 12vw 7%;
+      padding: 4em 6vw 8em;
+  }
+
+  .thumbnailbox {
+      grid-column: span 6;
+  }
+
+  .thumbnailtitle {
+      font-size: 3.5vw;
+  }
+    
+  .thumbnailblurb {
+      font-size: 2.5vw;
+  }
+}
+
+@media screen and (max-width: 480px) {
+  #thumbnaillist {
+      gap: 35vw 5%;
+      padding: 4em 6vw 8em;
+  }
+
+  .thumbnailbox {
+      grid-column: span 12;
+  }
+
+  .thumbnailtitle {
+      font-size: 6.5vw;
+  }
+    
+  .thumbnailblurb {
+      font-size: 5vw;
+  }
+
   #resourcenavbar {
-    flex-direction: column;
+      flex-direction: column;
   }
 }

--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -64,12 +64,12 @@ h1 {
   font-family: "Roboto Condensed";
   font-style: normal;
   font-weight: 700;
-  font-size: 1.5vw;
+  font-size: 1.6vw;
 }
 
 .thumbnailblurb {
   color: #000;
-  font-size: 1.2vw;
+  font-size: 1.3vw;
   font-family: "Source Sans Pro";
   font-style: normal;
   font-weight: 400;

--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -5,8 +5,7 @@
 body {
   font-family: sans-serif;
   margin: 0;
-  display: flex;
-  flex-direction: column;
+  width: 100%;
   padding: 0 0 0;
 }
 

--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -37,7 +37,7 @@ h1 {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
   margin: 4em 0 0;
-  padding: 4em 10vw 8em;
+  padding: 4em 10vw 16em;
   gap: 10% 5%;
   box-sizing: border-box;
   width: 100%;
@@ -48,6 +48,7 @@ h1 {
 
 .thumbnailbox {
   grid-column: span 3;
+  height: fit-content;
 }
 
 .thumbnailLink {

--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -15,8 +15,8 @@ main {
 }
 
 main a {
-cursor: pointer;
-height: fit-content;
+  cursor: pointer;
+  height: fit-content;
 }
 
 h1 {
@@ -61,8 +61,8 @@ h1 {
   color: #000;
   font-size: 1.2vw;
   font-family: "Source Sans Pro";
-    font-style: normal;
-    font-weight: 400;
+  font-style: normal;
+  font-weight: 400;
 }
 
 /* Styles For resource.html */

--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -14,10 +14,6 @@ header {
 }
 
 /* Styles common for all the pages*/
-body.listing-page {
-  box-sizing: border-box;
-}
-
 main {
   width: 100%;
   padding: 0 0;

--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -154,6 +154,10 @@ h1 {
 
 
 /* Styles For footer.html */
+footer {
+  width: 100%;
+}
+
 footer a {
   color: var(--vocabulary-brand-color-turquoise);
 }

--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -41,7 +41,7 @@ h1 {
 }
 
 .thumbnailLink {
-  text-decoration: none;
+  --underline-background-color: var(--vocabulary-neutral-color-lighter-gray);
 }
 
 .thumbnail {
@@ -55,14 +55,14 @@ h1 {
   font-style: normal;
   font-weight: 700;
   font-size: 1.5vw;
-  color: var(--vocabulary-brand-color-dark-tomato);
-  --underline-background-color: var(--vocabulary-neutral-color-lighter-gray);
-  --underline-color: var(--vocabulary-brand-color-dark-tomato);
 }
 
 .thumbnailblurb {
-  height: 100px;
-  padding: 5px;
+  color: #000;
+  font-size: 1.2vw;
+  font-family: "Source Sans Pro";
+    font-style: normal;
+    font-weight: 400;
 }
 
 /* Styles For resource.html */

--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -2,9 +2,6 @@
 @import "/_assets/vocabulary/css/vocabulary.css" layer(vocabulary);
 
 /* CSS for All Pages */
-* {
-  box-sizing: border-box;
-}
 
 body {
   font-family: sans-serif;

--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -9,7 +9,8 @@ body {
   padding: 0 0 0;
 }
 
-/* Styles for listing.html and submission.html*/
+
+/* Styles common for all the pages*/
 main {
   width: 100%;
 }
@@ -22,6 +23,7 @@ main a {
 h1 {
   text-align: center;
 }
+
 
 /* Styles for listing.html resource thumbnail cards */
 #thumbnaillist {
@@ -64,6 +66,32 @@ h1 {
   font-style: normal;
   font-weight: 400;
 }
+
+
+/* Styles For index.html and all.html */
+#resourcenavbar {
+  height: fit-content;
+  margin: 0 auto 100px;
+  display: flex;
+  justify-content: center;
+}
+
+.resourcenav {
+  width: 200px;
+  height: fit-content;
+  display: none;
+}
+
+.resourcenav.resourcenavstatic {
+  display: block;
+}
+
+#bannercc {
+  width: 210px;
+  height: 50px;
+  margin-left: 100px;
+}
+
 
 /* Styles For resource.html */
 #preview {
@@ -111,29 +139,9 @@ h1 {
   color: white;
 }
 
-/* Styles For index.html and all.html */
-#resourcenavbar {
-  height: fit-content;
-  margin: 0 auto 100px;
-  display: flex;
-  justify-content: center;
-}
 
-.resourcenav {
-  width: 200px;
-  height: fit-content;
-  display: none;
-}
+/* Styles for submission.html */
 
-.resourcenav.resourcenavstatic {
-  display: block;
-}
-
-#bannercc {
-  width: 210px;
-  height: 50px;
-  margin-left: 100px;
-}
 
 /* Styles For footer.html */
 footer a {
@@ -143,6 +151,7 @@ footer a {
 footer .donate a {
   color: #000;
 }
+
 
 /* Media Queries for responsiveness */
 @media screen and (max-width: 600px) {

--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -35,12 +35,8 @@ h1 {
 }
 
 .thumbnailbox {
-  width: 200px;
-  float: left;
-  display: block;
-  border-radius: 25px;
-  border: 2px solid #c0c0c0;
-  margin: 5px;
+  grid-column: span 3;
+  border: 2px solid black;
 }
 
 .thumbnailLink {

--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -50,8 +50,13 @@ h1 {
 }
 
 .thumbnailtitle {
-  text-align: center;
-  height: 75px;
+    font-family:"Roboto Condensed";
+      font-style: normal;
+      font-weight: 700;
+    font-size: 1.5vw;
+    color: var(--vocabulary-brand-color-dark-tomato);
+    --underline-background-color: var(--vocabulary-neutral-color-lighter-gray);
+    --underline-color: var(--vocabulary-brand-color-dark-tomato);
 }
 
 .thumbnailblurb {

--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -21,6 +21,7 @@ header {
 /* Styles common for all the pages*/
 main {
   width: 100%;
+  padding: 0 0;
 }
 
 main a {
@@ -37,8 +38,8 @@ h1 {
 #thumbnaillist {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
-  margin: 4em 0 8em;
-  padding: 4em var(--vocabulary-page-edges-space);
+  margin: 4em 0 0;
+  padding: 4em var(--vocabulary-page-edges-space) 8em;
   gap: 5%;
   box-sizing: border-box;
   width: 100%;

--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -161,6 +161,25 @@ footer .donate a {
 }
 
 /* Media Queries for responsiveness */
+@media screen and (max-width: 1024px) {
+  #thumbnaillist {
+      gap: 6vw 5%;
+      padding: 4em 7vw 8em;
+  }
+
+  .thumbnailbox {
+      grid-column: span 4;
+  }
+
+  .thumbnailtitle {
+      font-size: 2.4vw;
+  }
+    
+  .thumbnailblurb {
+      font-size: 1.7vw;
+  }
+}
+
 @media screen and (max-width: 600px) {
   #resourcenavbar {
     flex-direction: column;

--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -22,9 +22,16 @@ h1 {
 
 /* Styles for listing.html resource thumbnail cards */
 #thumbnaillist {
-  max-width: 900px;
-  min-width: 250px;
-  margin: 0 auto;
+  display: grid;
+    grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
+    margin: 4em 0 8em;
+    padding: 4em var(--vocabulary-page-edges-space);;
+    gap: 5%;
+    box-sizing: border-box;
+
+    width:100%;
+    height: fit-content;
+    background: var(--vocabulary-neutral-color-lighter-gray);
 }
 
 .thumbnailbox {

--- a/docs/_layouts/listing.html
+++ b/docs/_layouts/listing.html
@@ -76,7 +76,7 @@
     {% endif %}
   </head>
 
-  <body class="listing-page">
+  <body>
     {% include header.html %}
 
     <main>

--- a/docs/_layouts/listing.html
+++ b/docs/_layouts/listing.html
@@ -79,7 +79,7 @@
   <body>
     {% include header.html %}
 
-    <div class="main-content">
+    <main>
       {{content}}
 
       <p style="text-align: center; padding: 1em">
@@ -124,7 +124,7 @@
         {% endif %} {% endunless %} {% endif %} {% endif %} {% endfor %} {%
         endfor %} {% endunless %}
       </div>
-    </div>
+    </main>
 
     <!-- Footer -->
     {% include footer.html %}

--- a/docs/_layouts/listing.html
+++ b/docs/_layouts/listing.html
@@ -89,24 +89,28 @@
       <ul id="thumbnaillist">
         {% for i in (1..16) %} {% for page in site.pages %} {% if page.layout ==
         'resource' %} {% if page.featured == i %}
-        <li class="thumbnailbox {{ page.topic }} {{ page.medium }} {{page.language}}"><article>
+        <li class="thumbnailbox {{ page.topic }} {{ page.medium }} {{page.language}}">
+          <article>
 
-          <img class="thumbnail" src="{{page.image-thumb}}"></img>
-          <h3 class="thumbnailtitle"><a class="thumbnailLink" href="{{ page.permalink }}">{{ page.title }}</a></h3>
-          <p class="thumbnailblurb">{{ page.blurb }}</p>
+            <img class="thumbnail" src="{{page.image-thumb}}"></img>
+            <h3 class="thumbnailtitle"><a class="thumbnailLink" href="{{ page.permalink }}">{{ page.title }}</a></h3>
+            <p class="thumbnailblurb">{{ page.blurb }}</p>
 
-        </article></li>
+          </article>
+        </li>
         {% endif %} {% endif %} {% endfor %} {% endfor %} {% unless page.title
         == 'Home' %} {% for i in (1..4) %} {% for page in site.pages %} {% if
         page.layout == 'resource' %} {% if page.weight == i %} {% unless
         page.featured %} {% if page.paramfilter == page.paramvalue %}
-        <li class="thumbnailbox {{ page.topic }} {{ page.medium }} {{page.language}}"><article>
+        <li class="thumbnailbox {{ page.topic }} {{ page.medium }} {{page.language}}">
+          <article>
 
-          <img class="thumbnail" src="{{page.image-thumb}}"></img>
-          <h3 class="thumbnailtitle"><a class="thumbnailLink" href="{{ page.permalink }}">{{ page.title }}</a></h3>
-          <p class="thumbnailblurb">{{ page.blurb }}</p>
+            <img class="thumbnail" src="{{page.image-thumb}}"></img>
+            <h3 class="thumbnailtitle"><a class="thumbnailLink" href="{{ page.permalink }}">{{ page.title }}</a></h3>
+            <p class="thumbnailblurb">{{ page.blurb }}</p>
 
-        </article></li>
+          </article>
+        </li>
         {% endif %} {% endunless %} {% endif %} {% endif %} {% endfor %} {%
         endfor %} {% endunless %}
       </ul>

--- a/docs/_layouts/listing.html
+++ b/docs/_layouts/listing.html
@@ -92,16 +92,9 @@
         <div
           class="thumbnailbox {{ page.topic }} {{ page.medium }} {{page.language}}"
         >
-          <a class="thumbnailLink" href="{{ page.permalink }}">
-            <img
-              class="thumbnail"
-              src="{{page.image-thumb}}"
-            ></img>
-            <div class="thumbnailtitle"><h3>{{ page.title }}</h3></div>
-            <div class="thumbnailblurb" style="color: rgb(0, 0, 0)">
-              {{ page.blurb }}
-            </div>
-          </a>
+            <img class="thumbnail" src="{{page.image-thumb}}"></img>
+            <h3 class="thumbnailtitle"><a class="thumbnailLink" href="{{ page.permalink }}">{{ page.title }}</a></h3>
+            <p class="thumbnailblurb">{{ page.blurb }}</p>
         </div>
         {% endif %} {% endif %} {% endfor %} {% endfor %} {% unless page.title
         == 'Home' %} {% for i in (1..4) %} {% for page in site.pages %} {% if
@@ -110,16 +103,9 @@
         <div
           class="thumbnailbox {{ page.topic }} {{ page.medium }} {{page.language}}"
         >
-          <a class="thumbnailLink" href="{{ page.permalink }}">
-            <img
-              class="thumbnail"
-              src="{{page.image-thumb}}"
-            ></img>
-            <div class="thumbnailtitle"><h3>{{ page.title }}</h3></div>
-            <div class="thumbnailblurb" style="color: rgb(0, 0, 0)">
-              {{ page.blurb }}
-            </div>
-          </a>
+            <img class="thumbnail" src="{{page.image-thumb}}"></img>
+            <h3 class="thumbnailtitle"><a class="thumbnailLink" href="{{ page.permalink }}">{{ page.title }}</a></h3>
+            <p class="thumbnailblurb">{{ page.blurb }}</p>
         </div>
         {% endif %} {% endunless %} {% endif %} {% endif %} {% endfor %} {%
         endfor %} {% endunless %}

--- a/docs/_layouts/listing.html
+++ b/docs/_layouts/listing.html
@@ -89,24 +89,24 @@
       <div id="thumbnaillist">
         {% for i in (1..16) %} {% for page in site.pages %} {% if page.layout ==
         'resource' %} {% if page.featured == i %}
-        <div
-          class="thumbnailbox {{ page.topic }} {{ page.medium }} {{page.language}}"
-        >
-            <img class="thumbnail" src="{{page.image-thumb}}"></img>
-            <h3 class="thumbnailtitle"><a class="thumbnailLink" href="{{ page.permalink }}">{{ page.title }}</a></h3>
-            <p class="thumbnailblurb">{{ page.blurb }}</p>
+        <div class="thumbnailbox {{ page.topic }} {{ page.medium }} {{page.language}}">
+
+          <img class="thumbnail" src="{{page.image-thumb}}"></img>
+          <h3 class="thumbnailtitle"><a class="thumbnailLink" href="{{ page.permalink }}">{{ page.title }}</a></h3>
+          <p class="thumbnailblurb">{{ page.blurb }}</p>
+
         </div>
         {% endif %} {% endif %} {% endfor %} {% endfor %} {% unless page.title
         == 'Home' %} {% for i in (1..4) %} {% for page in site.pages %} {% if
         page.layout == 'resource' %} {% if page.weight == i %} {% unless
         page.featured %} {% if page.paramfilter == page.paramvalue %}
-        <div
-          class="thumbnailbox {{ page.topic }} {{ page.medium }} {{page.language}}"
-        >
-            <img class="thumbnail" src="{{page.image-thumb}}"></img>
-            <h3 class="thumbnailtitle"><a class="thumbnailLink" href="{{ page.permalink }}">{{ page.title }}</a></h3>
-            <p class="thumbnailblurb">{{ page.blurb }}</p>
-        </div>
+        <div class="thumbnailbox {{ page.topic }} {{ page.medium }} {{page.language}}">
+
+          <img class="thumbnail" src="{{page.image-thumb}}"></img>
+          <h3 class="thumbnailtitle"><a class="thumbnailLink" href="{{ page.permalink }}">{{ page.title }}</a></h3>
+          <p class="thumbnailblurb">{{ page.blurb }}</p>
+
+      </div>
         {% endif %} {% endunless %} {% endif %} {% endif %} {% endfor %} {%
         endfor %} {% endunless %}
       </div>

--- a/docs/_layouts/listing.html
+++ b/docs/_layouts/listing.html
@@ -86,30 +86,30 @@
         <a href="/submit/">Submit a resource</a>
       </p>
 
-      <div id="thumbnaillist">
+      <article id="thumbnaillist">
         {% for i in (1..16) %} {% for page in site.pages %} {% if page.layout ==
         'resource' %} {% if page.featured == i %}
-        <div class="thumbnailbox {{ page.topic }} {{ page.medium }} {{page.language}}">
+        <article class="thumbnailbox {{ page.topic }} {{ page.medium }} {{page.language}}">
 
           <img class="thumbnail" src="{{page.image-thumb}}"></img>
           <h3 class="thumbnailtitle"><a class="thumbnailLink" href="{{ page.permalink }}">{{ page.title }}</a></h3>
           <p class="thumbnailblurb">{{ page.blurb }}</p>
 
-        </div>
+        </article>
         {% endif %} {% endif %} {% endfor %} {% endfor %} {% unless page.title
         == 'Home' %} {% for i in (1..4) %} {% for page in site.pages %} {% if
         page.layout == 'resource' %} {% if page.weight == i %} {% unless
         page.featured %} {% if page.paramfilter == page.paramvalue %}
-        <div class="thumbnailbox {{ page.topic }} {{ page.medium }} {{page.language}}">
+        <article class="thumbnailbox {{ page.topic }} {{ page.medium }} {{page.language}}">
 
           <img class="thumbnail" src="{{page.image-thumb}}"></img>
           <h3 class="thumbnailtitle"><a class="thumbnailLink" href="{{ page.permalink }}">{{ page.title }}</a></h3>
           <p class="thumbnailblurb">{{ page.blurb }}</p>
 
-      </div>
+        </article>
         {% endif %} {% endunless %} {% endif %} {% endif %} {% endfor %} {%
         endfor %} {% endunless %}
-      </div>
+      </article>
     </main>
 
     <!-- Footer -->

--- a/docs/_layouts/listing.html
+++ b/docs/_layouts/listing.html
@@ -93,11 +93,11 @@
           class="thumbnailbox {{ page.topic }} {{ page.medium }} {{page.language}}"
         >
           <a class="thumbnailLink" href="{{ page.permalink }}">
-            <div class="thumbnailtitle"><h3>{{ page.title }}</h3></div>
-            <div
+            <img
               class="thumbnail"
-              style="background-image: url({{ page.image-thumb }});"
-            ></div>
+              src="{{page.image-thumb}}"
+            ></img>
+            <div class="thumbnailtitle"><h3>{{ page.title }}</h3></div>
             <div class="thumbnailblurb" style="color: rgb(0, 0, 0)">
               {{ page.blurb }}
             </div>
@@ -111,11 +111,11 @@
           class="thumbnailbox {{ page.topic }} {{ page.medium }} {{page.language}}"
         >
           <a class="thumbnailLink" href="{{ page.permalink }}">
-            <div class="thumbnailtitle"><h3>{{ page.title }}</h3></div>
-            <div
+            <img
               class="thumbnail"
-              style="background-image: url('{{ page.image-thumb }}'); "
-            ></div>
+              src="{{page.image-thumb}}"
+            ></img>
+            <div class="thumbnailtitle"><h3>{{ page.title }}</h3></div>
             <div class="thumbnailblurb" style="color: rgb(0, 0, 0)">
               {{ page.blurb }}
             </div>

--- a/docs/_layouts/listing.html
+++ b/docs/_layouts/listing.html
@@ -86,30 +86,30 @@
         <a href="/submit/">Submit a resource</a>
       </p>
 
-      <article id="thumbnaillist">
+      <ul id="thumbnaillist">
         {% for i in (1..16) %} {% for page in site.pages %} {% if page.layout ==
         'resource' %} {% if page.featured == i %}
-        <article class="thumbnailbox {{ page.topic }} {{ page.medium }} {{page.language}}">
+        <li class="thumbnailbox {{ page.topic }} {{ page.medium }} {{page.language}}"><article>
 
           <img class="thumbnail" src="{{page.image-thumb}}"></img>
           <h3 class="thumbnailtitle"><a class="thumbnailLink" href="{{ page.permalink }}">{{ page.title }}</a></h3>
           <p class="thumbnailblurb">{{ page.blurb }}</p>
 
-        </article>
+        </article></li>
         {% endif %} {% endif %} {% endfor %} {% endfor %} {% unless page.title
         == 'Home' %} {% for i in (1..4) %} {% for page in site.pages %} {% if
         page.layout == 'resource' %} {% if page.weight == i %} {% unless
         page.featured %} {% if page.paramfilter == page.paramvalue %}
-        <article class="thumbnailbox {{ page.topic }} {{ page.medium }} {{page.language}}">
+        <li class="thumbnailbox {{ page.topic }} {{ page.medium }} {{page.language}}"><article>
 
           <img class="thumbnail" src="{{page.image-thumb}}"></img>
           <h3 class="thumbnailtitle"><a class="thumbnailLink" href="{{ page.permalink }}">{{ page.title }}</a></h3>
           <p class="thumbnailblurb">{{ page.blurb }}</p>
 
-        </article>
+        </article></li>
         {% endif %} {% endunless %} {% endif %} {% endif %} {% endfor %} {%
         endfor %} {% endunless %}
-      </article>
+      </ul>
     </main>
 
     <!-- Footer -->

--- a/docs/_layouts/listing.html
+++ b/docs/_layouts/listing.html
@@ -76,7 +76,7 @@
     {% endif %}
   </head>
 
-  <body>
+  <body class="listing-page">
     {% include header.html %}
 
     <main>


### PR DESCRIPTION
## Fixes
- Fixes #297 by @Murdock9803 
- Fixes #176 by @siddrs
- Related to #61 by @RishabhRajJoshi

## Description
The pull request works mainly on the section where all the `resource cards` are being displayed. This focuses on improving the design and style of the cards based on the `vocabulary` directory. The pull request also focuses on the responsiveness of the `resource grid`.

## Technical details
The Pull request performs the following actions:
- Refactored the structure of resource card to IMAGE - TITLE - BLURB in `listing.html`
- Utilising vocabulary, enhanced the style for `#thumbnaillist` in `listing.html`. Worked on the `grid structure` in `style.css`.
- Likewise, worked on enhancing style for `.thumbnailbox`, `.thumbnailtitle`, `.thumbnail` and `thumbnailblurb`. 
- Worked on Fonts, colors, background colors, etc. according to vocabulary.
- Assigned properties like `--underline-background-color` from vocabulary into style.css
- Formatted the `style.css` and `listing.html` files with `prettier`
- Fixed the responsiveness of the resource cards.
- Added Documentation in style.css for understandability.

## Screenshots
Some screenshots after the work has been done:
![image](https://github.com/creativecommons/cc-resource-archive/assets/136724527/2cebcdb9-1f01-4efc-b2f7-2e8360fa92d7)

For medium sized screens (the columns become 3 in number):
![image](https://github.com/creativecommons/cc-resource-archive/assets/136724527/776547da-156c-40ff-b56f-0600fdda7ebf)

For  small sized screens (the columns become 2 in number):
![image](https://github.com/creativecommons/cc-resource-archive/assets/136724527/7d421aa8-ca4d-470c-b917-43f512a4ae74)

For mobile screens (single column):
![image](https://github.com/creativecommons/cc-resource-archive/assets/136724527/4e3e0b8d-a575-4da6-91c5-4cd45d25a9d8)


## Additional Context
The inspiration for the design of resource cards has been drawn from the [vocabulary blog-index page](https://creativecommons-prototype.netlify.app/context/blog-index.html)

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
