### PR TITLE
displayed a message when no resources are found matching the filters

### DIFF
--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -47,6 +47,10 @@ h1 {
   list-style: none;
 }
 
+#noThumbnailsMessage h1{
+  text-align: center;
+}
+
 .thumbnailbox {
   grid-column: span 3;
   height: fit-content;

--- a/docs/_assets/js/listing.js
+++ b/docs/_assets/js/listing.js
@@ -117,3 +117,21 @@ if (language) {
   isFilterSelected += ", .resourcenavlanguageunknown";
 }
 dynamicStyle.innerHTML += `${isFilterSelected} { display: block; }`;
+
+
+document.addEventListener('DOMContentLoaded', function () {
+  // Check if all thumbnailbox elements are hidden
+  var thumbnailBoxes = document.querySelectorAll('.thumbnailbox');
+  var allHidden = true;
+  
+  thumbnailBoxes.forEach(function (box) {
+      if (window.getComputedStyle(box).display !== 'none') {
+          allHidden = false;
+      }
+  });
+
+  // Show the message if all thumbnailbox elements are hidden
+  if (allHidden) {
+      document.getElementById('noThumbnailsMessage').style.display = 'block';
+  }
+});

--- a/docs/_layouts/listing.html
+++ b/docs/_layouts/listing.html
@@ -50,6 +50,9 @@
 
       <!-- This is the section that shows all the resource cards in the site.
        The homepage shows upto 16 'featured' items ordered (1) to (16 or lesser) -->
+       <div id="noThumbnailsMessage" style="display: none;">
+        <h1>No resources matched the selected filters.</h1>
+        </div> 
       <ul id="thumbnaillist">
         {% for i in (1..16) %} {% for page in site.pages %} {% if page.layout
         =='resource' %} {% if page.featured == i %}
@@ -91,7 +94,7 @@
         {% endif %} {% endunless %} {% endif %} {% endif %} {% endfor %} {%
         endfor %} {% endunless %}
       </ul>
-    </main>
+    </main>   
 
     <!-- The standard CC footer, located at docs/_includes/footer.html -->
     {% include footer.html %}


### PR DESCRIPTION
## Fixes
- Fixes #295  by @Murdock9803 

## Description
Added a feature to display a message when no resources match the selected combination of filters in the topic, medium, and language categories. This enhancement ensures that users are informed when their filter criteria do not yield any results, preventing confusion and providing clarity on the absence of matching resources.

## Screenshots
<img width="1440" alt="Screenshot 2024-07-08 at 10 50 56 PM" src="https://github.com/creativecommons/cc-resource-archive/assets/145771776/8a3c84f8-6e5c-4889-99e1-2ebd3beae718">

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.