### PR TITLE
Added alt-text to thumbnail images

### DIFF
--- a/docs/_layouts/listing.html
+++ b/docs/_layouts/listing.html
@@ -57,7 +57,7 @@
           class="thumbnailbox {{ page.topic }} {{ page.medium }} {{page.language}}"
         >
           <article>
-            <img class="thumbnail" src="{{page.image-thumb}}" />
+            <img class="thumbnail" src="{{page.image-thumb}}" alt="{{page.title}}"/>
             <h3 class="thumbnailtitle">
               <a class="thumbnailLink" href="{{ page.permalink }}"
                 >{{ page.title }}</a
@@ -79,7 +79,7 @@
           class="thumbnailbox {{ page.topic }} {{ page.medium }} {{page.language}}"
         >
           <article>
-            <img class="thumbnail" src="{{page.image-thumb}}" />
+            <img class="thumbnail" src="{{page.image-thumb}}" alt="{{page.title}}"/>
             <h3 class="thumbnailtitle">
               <a class="thumbnailLink" href="{{ page.permalink }}"
                 >{{ page.title }}</a


### PR DESCRIPTION
## Fixes
- Fixes #307  by @Murdock9803 

## Description
This PR addresses issue #307 by adding appropriate alt attributes to the <img> tags with the class thumbnail in the listing.html file. The alt text has been set to the title of each image, providing a more descriptive and accessible experience for users.

## Changes
- Added alt attributes to the <img> tags inside #thumbnaillist in docs/_layouts/listing.html.
- Used the title of each image as the alt text to ensure it accurately describes the image content.

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

