### PR TITLE
Fixes #303. Replaced dynamic styling with class-based CSS approach.

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -270,6 +270,7 @@ GEM
 PLATFORMS
   aarch64-linux
   arm64-darwin-23
+  x86_64-linux
   x86_64-linux-musl
 
 DEPENDENCIES

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -270,7 +270,6 @@ GEM
 PLATFORMS
   aarch64-linux
   arm64-darwin-23
-  x86_64-linux
   x86_64-linux-musl
 
 DEPENDENCIES

--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -232,33 +232,6 @@ footer a {
 footer .donate a {
   color: #000;
 }
-/* Add these new classes for visibility control */
-.hidden {
-  display: none;
-}
-
-.visible {
-  display: block;
-}
-
-/* Add classes for resourcenav elements */
-.resourcenavtopicknown,
-.resourcenavtopicunknown,
-.resourcenavmediumknown,
-.resourcenavmediumunknown,
-.resourcenavlanguageknown,
-.resourcenavlanguageunknown {
-  display: none;
-}
-
-.resourcenavtopicknown.visible,
-.resourcenavtopicunknown.visible,
-.resourcenavmediumknown.visible,
-.resourcenavmediumunknown.visible,
-.resourcenavlanguageknown.visible,
-.resourcenavlanguageunknown.visible {
-  display: block;
-}
 
 /* Media Queries for responsiveness */
 @media screen and (max-width: 1200px) {

--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -237,10 +237,6 @@ footer .donate a {
   display: none;
 }
 
-.visible {
-  display: block;
-}
-
 /* Add classes for resourcenav elements */
 .resourcenavtopicknown,
 .resourcenavtopicunknown,
@@ -249,15 +245,6 @@ footer .donate a {
 .resourcenavlanguageknown,
 .resourcenavlanguageunknown {
   display: none;
-}
-
-.resourcenavtopicknown.visible,
-.resourcenavtopicunknown.visible,
-.resourcenavmediumknown.visible,
-.resourcenavmediumunknown.visible,
-.resourcenavlanguageknown.visible,
-.resourcenavlanguageunknown.visible {
-  display: block;
 }
 
 /* Media Queries for responsiveness */

--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -232,6 +232,33 @@ footer a {
 footer .donate a {
   color: #000;
 }
+/* Add these new classes for visibility control */
+.hidden {
+  display: none;
+}
+
+.visible {
+  display: block;
+}
+
+/* Add classes for resourcenav elements */
+.resourcenavtopicknown,
+.resourcenavtopicunknown,
+.resourcenavmediumknown,
+.resourcenavmediumunknown,
+.resourcenavlanguageknown,
+.resourcenavlanguageunknown {
+  display: none;
+}
+
+.resourcenavtopicknown.visible,
+.resourcenavtopicunknown.visible,
+.resourcenavmediumknown.visible,
+.resourcenavmediumunknown.visible,
+.resourcenavlanguageknown.visible,
+.resourcenavlanguageunknown.visible {
+  display: block;
+}
 
 /* Media Queries for responsiveness */
 @media screen and (max-width: 1200px) {

--- a/docs/_assets/js/listing.js
+++ b/docs/_assets/js/listing.js
@@ -72,16 +72,20 @@ function getUrlVars() {
 // assigning variable to the filters selected by user (retrieved by getUrlVars)
 const { topic, language, medium } = getUrlVars();
 
-// Setting every thumbnailbox to display:none by creating a new element "dynamicStyle".
-// This "dynamicStyle" element can be used to create all the dynamic styles.
-const dynamicStyle = document.createElement("style");
-dynamicStyle.type = "text/css";
-dynamicStyle.innerHTML = ".thumbnailbox { display: none; }";
-document.head.appendChild(dynamicStyle);
+// Function to update the visibility of elements based on filters
+function updateVisibility() {
 
-// If no filter is selected, display all the resources by "display:block"
+  const thumbnailBoxes = document.querySelectorAll(".thumbnailbox");
+  thumbnailBoxes.forEach(box => {
+    box.classList.add("hidden");
+    box.classList.remove("visible");
+  });
+
 if (!topic && !medium && !language) {
-  dynamicStyle.innerHTML += " .thumbnailbox { display: block; }";
+  thumbnailBoxes.forEach(box => {
+    box.classList.remove("hidden");
+    box.classList.add("visible");
+  });
 } else {
   // If filter(s) is/are selected, display all the resources which have all the filters
   let selectedFilters = "";
@@ -94,7 +98,10 @@ if (!topic && !medium && !language) {
   if (language) {
     selectedFilters += `.${language}`;
   }
-  dynamicStyle.innerHTML += `${selectedFilters} { display: block; }`;
+  document.querySelectorAll(selectedFilters).forEach(box => {
+    box.classList.remove("hidden");
+    box.classList.add("visible");
+  });
 }
 
 // If user has selected some Topic filter, add class resourcenavtopicknown with "display:block".
@@ -116,4 +123,12 @@ if (language) {
 } else {
   isFilterSelected += ", .resourcenavlanguageunknown";
 }
-dynamicStyle.innerHTML += `${isFilterSelected} { display: block; }`;
+document.querySelectorAll(isFilterSelected).forEach(nav => {
+  nav.classList.remove("hidden");
+  nav.classList.add("visible");
+});
+
+}
+
+// Initial call to update visibility based on URL parameters
+updateVisibility();

--- a/docs/_assets/js/listing.js
+++ b/docs/_assets/js/listing.js
@@ -72,16 +72,21 @@ function getUrlVars() {
 // assigning variable to the filters selected by user (retrieved by getUrlVars)
 const { topic, language, medium } = getUrlVars();
 
-// Setting every thumbnailbox to display:none by creating a new element "dynamicStyle".
-// This "dynamicStyle" element can be used to create all the dynamic styles.
-const dynamicStyle = document.createElement("style");
-dynamicStyle.type = "text/css";
-dynamicStyle.innerHTML = ".thumbnailbox { display: none; }";
-document.head.appendChild(dynamicStyle);
+// Function to update the visibility of elements based on filters
+function updateVisibility() {
 
-// If no filter is selected, display all the resources by "display:block"
+  const thumbnailBoxes = document.querySelectorAll(".thumbnailbox");
+  thumbnailBoxes.forEach(box => {
+    box.classList.add("hidden");
+    box.classList.remove("visible");
+  });
+
+
 if (!topic && !medium && !language) {
-  dynamicStyle.innerHTML += " .thumbnailbox { display: block; }";
+  thumbnailBoxes.forEach(box => {
+    box.classList.remove("hidden");
+    box.classList.add("visible");
+  });
 } else {
   // If filter(s) is/are selected, display all the resources which have all the filters
   let selectedFilters = "";
@@ -94,12 +99,13 @@ if (!topic && !medium && !language) {
   if (language) {
     selectedFilters += `.${language}`;
   }
-  dynamicStyle.innerHTML += `${selectedFilters} { display: block; }`;
+  document.querySelectorAll(selectedFilters).forEach(box => {
+    box.classList.remove("hidden");
+    box.classList.add("visible");
+  });
+
 }
 
-// If user has selected some Topic filter, add class resourcenavtopicknown with "display:block".
-// Otherwise, add class resourcenavtopicunknown with "display:block"
-// This is for displaying the list of available filters to be selected from
 let isFilterSelected = "";
 if (topic) {
   isFilterSelected += " .resourcenavtopicknown";
@@ -116,4 +122,13 @@ if (language) {
 } else {
   isFilterSelected += ", .resourcenavlanguageunknown";
 }
-dynamicStyle.innerHTML += `${isFilterSelected} { display: block; }`;
+
+document.querySelectorAll(isFilterSelected).forEach(nav => {
+  nav.classList.remove("hidden");
+  nav.classList.add("visible");
+});
+
+}
+
+// Initial call to update visibility based on URL parameters
+updateVisibility();

--- a/docs/_assets/js/listing.js
+++ b/docs/_assets/js/listing.js
@@ -72,21 +72,16 @@ function getUrlVars() {
 // assigning variable to the filters selected by user (retrieved by getUrlVars)
 const { topic, language, medium } = getUrlVars();
 
-// Function to update the visibility of elements based on filters
-function updateVisibility() {
+// Setting every thumbnailbox to display:none by creating a new element "dynamicStyle".
+// This "dynamicStyle" element can be used to create all the dynamic styles.
+const dynamicStyle = document.createElement("style");
+dynamicStyle.type = "text/css";
+dynamicStyle.innerHTML = ".thumbnailbox { display: none; }";
+document.head.appendChild(dynamicStyle);
 
-  const thumbnailBoxes = document.querySelectorAll(".thumbnailbox");
-  thumbnailBoxes.forEach(box => {
-    box.classList.add("hidden");
-    box.classList.remove("visible");
-  });
-
-
+// If no filter is selected, display all the resources by "display:block"
 if (!topic && !medium && !language) {
-  thumbnailBoxes.forEach(box => {
-    box.classList.remove("hidden");
-    box.classList.add("visible");
-  });
+  dynamicStyle.innerHTML += " .thumbnailbox { display: block; }";
 } else {
   // If filter(s) is/are selected, display all the resources which have all the filters
   let selectedFilters = "";
@@ -99,13 +94,12 @@ if (!topic && !medium && !language) {
   if (language) {
     selectedFilters += `.${language}`;
   }
-  document.querySelectorAll(selectedFilters).forEach(box => {
-    box.classList.remove("hidden");
-    box.classList.add("visible");
-  });
-
+  dynamicStyle.innerHTML += `${selectedFilters} { display: block; }`;
 }
 
+// If user has selected some Topic filter, add class resourcenavtopicknown with "display:block".
+// Otherwise, add class resourcenavtopicunknown with "display:block"
+// This is for displaying the list of available filters to be selected from
 let isFilterSelected = "";
 if (topic) {
   isFilterSelected += " .resourcenavtopicknown";
@@ -122,13 +116,4 @@ if (language) {
 } else {
   isFilterSelected += ", .resourcenavlanguageunknown";
 }
-
-document.querySelectorAll(isFilterSelected).forEach(nav => {
-  nav.classList.remove("hidden");
-  nav.classList.add("visible");
-});
-
-}
-
-// Initial call to update visibility based on URL parameters
-updateVisibility();
+dynamicStyle.innerHTML += `${isFilterSelected} { display: block; }`;

--- a/docs/_assets/js/listing.js
+++ b/docs/_assets/js/listing.js
@@ -77,14 +77,12 @@ function updateVisibility() {
 
   const thumbnailBoxes = document.querySelectorAll(".thumbnailbox");
   thumbnailBoxes.forEach(box => {
-    box.classList.add("hidden");
-    box.classList.remove("visible");
+    box.classList.toggle("hidden", true);
   });
 
 if (!topic && !medium && !language) {
   thumbnailBoxes.forEach(box => {
-    box.classList.remove("hidden");
-    box.classList.add("visible");
+    box.classList.toggle("hidden", false);
   });
 } else {
   // If filter(s) is/are selected, display all the resources which have all the filters
@@ -99,8 +97,7 @@ if (!topic && !medium && !language) {
     selectedFilters += `.${language}`;
   }
   document.querySelectorAll(selectedFilters).forEach(box => {
-    box.classList.remove("hidden");
-    box.classList.add("visible");
+    box.classList.toggle("hidden", false);
   });
 }
 
@@ -124,8 +121,7 @@ if (language) {
   isFilterSelected += ", .resourcenavlanguageunknown";
 }
 document.querySelectorAll(isFilterSelected).forEach(nav => {
-  nav.classList.remove("hidden");
-  nav.classList.add("visible");
+  nav.classList.toggle("hidden", false);
 });
 
 }


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'.  -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #303 by @Murdock9803 

## Description

This PR addresses the issue where dynamic styling was being used to control the visibility of resource cards in the _assets/js/listing.js file. To enhance maintainability and consistency, the following updates were made:

Introduced new CSS utility classes (.hidden and .visible) to handle the visibility of resource elements without relying on dynamically injected styles.
Refactored the updateVisibility function to utilize these new classes, ensuring that elements are shown or hidden based on the user's filter selections (topic, medium, language).
Adjusted the resource navigation filters to dynamically apply the appropriate visibility classes, providing a cleaner and more efficient way to control the display of filters.
These changes align with the suggestion to replace dynamic styling with a class-based approach, making the codebase more consistent and easier to maintain.

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
