### PR TITLE
Fix #307 Alt Attribute Added

### DIFF
--- a/docs/_layouts/listing.html
+++ b/docs/_layouts/listing.html
@@ -71,7 +71,7 @@
             class="thumbnailbox {{ page.topic }} {{ page.medium }} {{page.language}}"
           >
             <article>
-              <img class="thumbnail" src="{{page.image-thumb}}" alt="{% if page.image_alt %}{{ page.image_alt }}{% else %}Default description of image{% endif %}"  />
+              <img class="thumbnail" src="{{page.image-thumb}}" alt='{% if page.image-alt %}{{ page.image-alt }}{% else %} {% endif %}'  />
               <h3 class="thumbnailtitle">
                 <a class="thumbnailLink" href="{{ page.permalink }}"
                   >{{ page.title }}</a
@@ -93,7 +93,7 @@
             class="thumbnailbox {{ page.topic }} {{ page.medium }} {{page.language}}"
           >
             <article>
-              <img class="thumbnail" src="{{page.image-thumb}}" alt="{% if page.image_alt %}{{ page.image_alt }}{% else %}Default description of image{% endif %}" />
+              <img class="thumbnail" src="{{page.image-thumb}}" alt='{% if page.image-alt %}{{ page.image-alt }}{% else %} {% endif %}' />
               <h3 class="thumbnailtitle">
                 <a class="thumbnailLink" href="{{ page.permalink }}"
                   >{{ page.title }}</a

--- a/docs/_layouts/listing.html
+++ b/docs/_layouts/listing.html
@@ -71,7 +71,7 @@
             class="thumbnailbox {{ page.topic }} {{ page.medium }} {{page.language}}"
           >
             <article>
-              <img class="thumbnail" src="{{page.image-thumb}}" />
+              <img class="thumbnail" src="{{page.image-thumb}}" alt="{% if page.image_alt %}{{ page.image_alt }}{% else %}Default description of image{% endif %}"  />
               <h3 class="thumbnailtitle">
                 <a class="thumbnailLink" href="{{ page.permalink }}"
                   >{{ page.title }}</a
@@ -93,7 +93,7 @@
             class="thumbnailbox {{ page.topic }} {{ page.medium }} {{page.language}}"
           >
             <article>
-              <img class="thumbnail" src="{{page.image-thumb}}" />
+              <img class="thumbnail" src="{{page.image-thumb}}" alt="{% if page.image_alt %}{{ page.image_alt }}{% else %}Default description of image{% endif %}" />
               <h3 class="thumbnailtitle">
                 <a class="thumbnailLink" href="{{ page.permalink }}"
                   >{{ page.title }}</a

--- a/docs/_layouts/resource.html
+++ b/docs/_layouts/resource.html
@@ -41,11 +41,11 @@
 
       <!-- else, display the {image-full} image here -->
       {% if page.image-full %}
-      <figure><img src="{{page.image-full}}" /></figure>
+      <figure><img src="{{page.image-full}}" alt="{% if page.image-alt %}{{ page.image-alt }}{% else %} {% endif %}" /></figure>
       {% else %}
 
       <!-- If the resource doesn't contain embed or image-full, display a placeholder here -->
-      <figure><img src="/_assets/images/placeholder-500.gif" /></figure>
+      <figure><img src="/_assets/images/placeholder-500.gif" alt="{% if page.image-alt %}{{ page.image-alt }}{% else %} {% endif %}"/></figure>
       {% endif %} {% endif %}
 
       <!-- The links to download, view or visit the resource are present here -->


### PR DESCRIPTION
### Add conditional alt attribute to image elements

**Fixes**
* Fixes #307 
Related to the issue that ensures better accessibility by providing detailed alt attributes to images, improving the user experience, especially for those using screen readers.

**Description**
This pull request adds a conditional alt attribute to the image elements in the thumbnail list. The change ensures that if an image_alt value is provided, it will be used; otherwise, a default description will be applied.


- If page.image_alt is defined, its value will be used as the alt text.
- If page.image_alt is not defined or is empty, the alt attribute will use "Default description of image" as the fallback.

**Technical details**
The alt attribute now checks if page.image_alt exists. If it does, that value is used. If not, a default description is applied, ensuring all images have an alt attribute for accessibility.

I tried running the project locally and verified that there are no visible errors.

