### PR TITLE
Replaced the dynamic styling in listing.js with class-based CSS approach

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -270,6 +270,7 @@ GEM
 PLATFORMS
   aarch64-linux
   arm64-darwin-23
+  x86_64-linux
   x86_64-linux-musl
 
 DEPENDENCIES

--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -38,6 +38,17 @@ code {
 }
 
 /* Styles for listing.html resource thumbnail cards */
+.hidden {
+  display: none;
+}
+.resourcenavtopicknown,
+.resourcenavtopicunknown,
+.resourcenavmediumknown,
+.resourcenavmediumunknown,
+.resourcenavlanguageknown,
+.resourcenavlanguageunknown {
+  display: none;
+}
 .listing-page main {
   padding: 0;
   width: 90%;
@@ -135,12 +146,12 @@ code {
   font-size: 1rem;
 }
 
-.resourcenav {
+.resourcenav.hidden {
   height: fit-content;
   display: none;
 }
 
-.resourcenav.resourcenavstatic {
+.resourcenav.resourcenavstatic.hidden {
   display: block;
 }
 

--- a/docs/_assets/js/listing.js
+++ b/docs/_assets/js/listing.js
@@ -72,48 +72,37 @@ function getUrlVars() {
 // assigning variable to the filters selected by user (retrieved by getUrlVars)
 const { topic, language, medium } = getUrlVars();
 
-// Setting every thumbnailbox to display:none by creating a new element "dynamicStyle".
-// This "dynamicStyle" element can be used to create all the dynamic styles.
-const dynamicStyle = document.createElement("style");
-dynamicStyle.type = "text/css";
-dynamicStyle.innerHTML = ".thumbnailbox { display: none; }";
-document.head.appendChild(dynamicStyle);
+// Setting every thumbnailbox to display:none 
+const allThumbnailBoxes = document.querySelector('.thumbnailbox')
 
-// If no filter is selected, display all the resources by "display:block"
-if (!topic && !medium && !language) {
-  dynamicStyle.innerHTML += " .thumbnailbox { display: block; }";
-} else {
-  // If filter(s) is/are selected, display all the resources which have all the filters
-  let selectedFilters = "";
-  if (topic) {
-    selectedFilters += `.${topic}`;
-  }
-  if (medium) {
-    selectedFilters += `.${medium}`;
-  }
-  if (language) {
-    selectedFilters += `.${language}`;
-  }
-  dynamicStyle.innerHTML += `${selectedFilters} { display: block; }`;
-}
+allThumbnailBoxes.forEach((box)=>{
+  box.classList.toggle('hidden', true)
+})
 
+// If no filter is selected, display all the resources 
+allThumbnailBoxes.forEach((box)=>{
+  let matchesFilters = true
+
+  if (topic && !box.classList.contains(topic)){
+    matchesFilters = false
+  }
+  if (medium && !box.classList.contains(medium)) {
+    matchesFilters = false;
+  }
+  if (language && !box.classList.contains(language)) {
+    matchesFilters = false;
+  }
+
+  box.classList.toggle("hidden", !matchesFilters); 
+})
 // If user has selected some Topic filter, add class resourcenavtopicknown with "display:block".
 // Otherwise, add class resourcenavtopicunknown with "display:block"
 // This is for displaying the list of available filters to be selected from
-let isFilterSelected = "";
-if (topic) {
-  isFilterSelected += " .resourcenavtopicknown";
-} else {
-  isFilterSelected += " .resourcenavtopicunknown";
-}
-if (medium) {
-  isFilterSelected += ", .resourcenavmediumknown";
-} else {
-  isFilterSelected += ", .resourcenavmediumunknown";
-}
-if (language) {
-  isFilterSelected += ", .resourcenavlanguageknown";
-} else {
-  isFilterSelected += ", .resourcenavlanguageunknown";
-}
-dynamicStyle.innerHTML += `${isFilterSelected} { display: block; }`;
+topicKnown.classList.toggle("hidden", !topic);
+topicUnknown.classList.toggle("hidden", !!topic);
+
+mediumKnown.classList.toggle("hidden", !medium);
+mediumUnknown.classList.toggle("hidden", !!medium);
+
+languageKnown.classList.toggle("hidden", !language);
+languageUnknown.classList.toggle("hidden", !!language);


### PR DESCRIPTION
## Fixes
- Fixes #303 by @Murdock9803 

## Description
This PR uses classList.toggle to replace the JavaScript code's dynamic styling method with a CSS-based method. This handles the visibility of elements based on filters through class toggling and resolves the issue of applying dynamic styles inline.

## Technical details
1. Replaced the dynamic creation of <style> elements with conditional class toggling using classList.toggle for better performance and maintainability.
2. The previous implementation relied on dynamically applying display: block or display: none styles. Now, the hidden class is added or removed based on the existence of topic, medium, and language filters.

## Tests
1. Navigate to the all.html page.
2. Apply topic, medium, and language filters and verify that the filtering works as expected without dynamic inline styles.
3. Verify that when no filters are applied, all resources are visible.
4. Ensure that filter toggling on the navigation works as expected.


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- x ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
