### PR TITLE
Fix: Added correct links for the licenses div in the footer

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -121,9 +121,9 @@
 
   <div class="license">
     <p>
-      Except where otherwise <a href="/policies/#license">noted</a>, content on
+      Except where otherwise <a href="https://creativecommons.org/policies/#license" target="_blank">noted</a>, content on
       this site is licensed under a
-      <a href="/licenses/by/4.0/"
+      <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank"
         >Creative Commons Attribution 4.0 International license</a
       >. Icons by
       <a href="https://fontawesome.com/" target="_blank">Font Awesome</a>.


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'.  -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #350  by @Queen-codes 

## Description
This PR adds appropriate links to the footer in the `div licenses` section and adds the target `_blank` for the links to be opened in another window.

## Tests
Open the resource archive website and scroll to the footer section, click on the links in the the Except stated otherwise paragraph.

## Screenshots
<img width="866" alt="Screenshot 2024-11-12 at 16 09 54" src="https://github.com/user-attachments/assets/a358ac4e-1849-4e7e-9837-56c60b851e92">


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
