### PR TITLE
Made submit page images and text responsive

### DIFF
--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -227,6 +227,11 @@ code {
   width: 100%;
 }
 
+.submit-page main > ol code {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
 /* Styles For footer.html */
 footer {
   box-sizing: border-box;

--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -210,6 +210,11 @@ code {
   margin: 0 auto 8em;
 }
 
+.submit-page > main a {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
 .submit-page main > header::before {
   left: unset;
 }

--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -218,6 +218,10 @@ code {
   margin: 1em 0;
 }
 
+.submit-page main > ol img {
+  width: 100%;
+}
+
 /* Styles For footer.html */
 footer {
   box-sizing: border-box;


### PR DESCRIPTION
## Fixes
- Fixes #370 by @Murdock9803

## Description
The pull request aims to make the `submit page` completely responsive to smaller screens, by improving the css around images and text to wrap.

## Technical details
The PR achieves this by adding `width` to images and `overflow-wrap` to the text wherever needed. The page is now completely responsive.

## Screenshots
<img width="249" height="683" alt="Screenshot 2025-09-10 091354" src="https://github.com/user-attachments/assets/8a3f7387-ddc4-444a-9fa8-f6803a818ac8" />
<img width="250" height="657" alt="Screenshot 2025-09-10 091418" src="https://github.com/user-attachments/assets/fea9cb9f-944f-42f1-a260-c1b280a6bcc5" />


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
