### PR TITLE
added clear filters button and improve accessibility in resource filters

### DIFF
--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -114,6 +114,34 @@ code {
   grid-area: sidebar;
 }
 
+/* Clear filters button styling */
+.clear-filters-wrapper {
+  text-align: center;
+  margin: 1em 0;
+}
+
+.clear-filters-btn {
+  background-color: var(--vocabulary-brand-color-tomato);
+  color: white;
+  border: none;
+  padding: 0.75em 1.5em;
+  font-size: 1rem;
+  font-family: 'Roboto Condensed', sans-serif;
+  font-weight: 700;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background-color 0.2s ease;
+}
+
+.clear-filters-btn:hover {
+  background-color: #a03600;
+}
+
+.clear-filters-btn:focus {
+  outline: 2px solid var(--vocabulary-brand-color-turquoise);
+  outline-offset: 2px;
+}
+
 #resourcenavbar h2 {
   text-align: center;
   font-size: 1.5em;
@@ -128,6 +156,27 @@ code {
 #resourcenavbar ul li {
   font-size: 1rem;
   margin-bottom: 1rem;
+}
+
+/* Improve checkbox and label accessibility */
+#resourcenavbar input[type="checkbox"] {
+  cursor: pointer;
+  margin-right: 0.5rem;
+}
+
+#resourcenavbar label {
+  cursor: pointer;
+  display: inline;
+}
+
+/* Add focus styles for keyboard navigation */
+#resourcenavbar input[type="checkbox"]:focus {
+  outline: 2px solid var(--vocabulary-brand-color-turquoise);
+  outline-offset: 2px;
+}
+
+#resourcenavbar label:hover {
+  text-decoration: underline;
 }
 
 #resourcenavbar p {

--- a/docs/_assets/css/style.css
+++ b/docs/_assets/css/style.css
@@ -114,7 +114,6 @@ code {
   grid-area: sidebar;
 }
 
-/* Clear filters button styling */
 .clear-filters-wrapper {
   text-align: center;
   margin: 1em 0;
@@ -134,7 +133,7 @@ code {
 }
 
 .clear-filters-btn:hover {
-  background-color: #a03600;
+  background-color: var(--vocabulary-brand-color-dark-tomato);
 }
 
 .clear-filters-btn:focus {
@@ -158,7 +157,6 @@ code {
   margin-bottom: 1rem;
 }
 
-/* Improve checkbox and label accessibility */
 #resourcenavbar input[type="checkbox"] {
   cursor: pointer;
   margin-right: 0.5rem;
@@ -169,7 +167,6 @@ code {
   display: inline;
 }
 
-/* Add focus styles for keyboard navigation */
 #resourcenavbar input[type="checkbox"]:focus {
   outline: 2px solid var(--vocabulary-brand-color-turquoise);
   outline-offset: 2px;

--- a/docs/_assets/js/listing.js
+++ b/docs/_assets/js/listing.js
@@ -117,3 +117,31 @@ if (language) {
   isFilterSelected += ", .resourcenavlanguageunknown";
 }
 dynamicStyle.innerHTML += `${isFilterSelected} { display: block; }`;
+
+// Show/hide clear filters button and setup event listener
+document.addEventListener('DOMContentLoaded', function() {
+  const clearButton = document.getElementById('clear-all-filters');
+  const clearWrapper = document.querySelector('.clear-filters-wrapper');
+  
+  // Show clear button only if any filter is active
+  if (topic || medium || language) {
+    if (clearWrapper) {
+      clearWrapper.style.display = 'block';
+    }
+  }
+  
+  // Clear all filters when button is clicked
+  if (clearButton) {
+    clearButton.addEventListener('click', function() {
+      window.location.href = window.location.pathname;
+    });
+    
+    // Allow keyboard activation (Enter/Space)
+    clearButton.addEventListener('keydown', function(e) {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        window.location.href = window.location.pathname;
+      }
+    });
+  }
+});

--- a/docs/_assets/js/listing.js
+++ b/docs/_assets/js/listing.js
@@ -118,30 +118,19 @@ if (language) {
 }
 dynamicStyle.innerHTML += `${isFilterSelected} { display: block; }`;
 
-// Show/hide clear filters button and setup event listener
 document.addEventListener('DOMContentLoaded', function() {
   const clearButton = document.getElementById('clear-all-filters');
   const clearWrapper = document.querySelector('.clear-filters-wrapper');
   
-  // Show clear button only if any filter is active
   if (topic || medium || language) {
     if (clearWrapper) {
       clearWrapper.style.display = 'block';
     }
   }
   
-  // Clear all filters when button is clicked
   if (clearButton) {
     clearButton.addEventListener('click', function() {
       window.location.href = window.location.pathname;
-    });
-    
-    // Allow keyboard activation (Enter/Space)
-    clearButton.addEventListener('keydown', function(e) {
-      if (e.key === 'Enter' || e.key === ' ') {
-        e.preventDefault();
-        window.location.href = window.location.pathname;
-      }
     });
   }
 });

--- a/docs/_pages/all.html
+++ b/docs/_pages/all.html
@@ -12,7 +12,7 @@ title: All
 <!-- If the user has selected a filter, resourcenavtopicknown will be displayed. otherwise resourcenavtopicunknown will be displayed -->
 <aside id="resourcenavbar" role="complementary" aria-label="Resource filters">
   
-  <div class="clear-filters-wrapper" style="display: none;">
+  <div class="clear-filters-wrapper hidden">
     <button id="clear-all-filters" class="clear-filters-btn" aria-label="Clear all active filters">
       Clear all filters
     </button>

--- a/docs/_pages/all.html
+++ b/docs/_pages/all.html
@@ -10,9 +10,16 @@ title: All
 <!-- This is the resourcenavbar, which contains the category filters. The categories are TOPIC, MEDIUM and LANGUAGE. In this there are two different options for displaying a category,
  For example - resourcenavtopicknown and resourcenavtopicunknown -->
 <!-- If the user has selected a filter, resourcenavtopicknown will be displayed. otherwise resourcenavtopicunknown will be displayed -->
-<aside id="resourcenavbar">
+<aside id="resourcenavbar" role="complementary" aria-label="Resource filters">
+  <!-- Clear all filters button - only visible when filters are active -->
+  <div class="clear-filters-wrapper" style="display: none;">
+    <button id="clear-all-filters" class="clear-filters-btn" aria-label="Clear all active filters">
+      Clear all filters
+    </button>
+  </div>
+  
   <article class="resourcenav resourcenavtopicknown">
-    <h2>Topic</h2>
+    <h2 id="topic-heading">Topic</h2>
     <p>
       <input
         type="checkbox"
@@ -28,8 +35,8 @@ title: All
   </article>
 
   <article class="resourcenav resourcenavtopicunknown topic-list">
-    <h2>Topic</h2>
-    <ul>
+    <h2 id="topic-heading">Topic</h2>
+    <ul role="group" aria-labelledby="topic-heading">
       {% for topic in site.data.topics %}
       <li>
         <input
@@ -45,7 +52,7 @@ title: All
   
 
   <article class="resourcenav resourcenavmediumknown">
-    <h2>Medium</h2>
+    <h2 id="medium-heading">Medium</h2>
     <p>
       <input
         type="checkbox"
@@ -61,8 +68,8 @@ title: All
   </article>
 
   <article class="resourcenav resourcenavmediumunknown medium-list">
-    <h2>Medium</h2>
-    <ul>
+    <h2 id="medium-heading">Medium</h2>
+    <ul role="group" aria-labelledby="medium-heading">
       {% for medium in site.data.media %}
       <li>
         <input
@@ -77,7 +84,7 @@ title: All
   </article>
 
   <article class="resourcenav resourcenavlanguageknown">
-    <h2>Language</h2>
+    <h2 id="language-heading">Language</h2>
     <p>
       <input
         type="checkbox"
@@ -94,8 +101,8 @@ title: All
   </article>
 
   <article class="resourcenav resourcenavlanguageunknown language-list">
-    <h2>Language</h2>
-    <ul>
+    <h2 id="language-heading">Language</h2>
+    <ul role="group" aria-labelledby="language-heading">
       {% for language in site.data.languages %}
       <li>
         <input

--- a/docs/_pages/all.html
+++ b/docs/_pages/all.html
@@ -11,7 +11,7 @@ title: All
  For example - resourcenavtopicknown and resourcenavtopicunknown -->
 <!-- If the user has selected a filter, resourcenavtopicknown will be displayed. otherwise resourcenavtopicunknown will be displayed -->
 <aside id="resourcenavbar" role="complementary" aria-label="Resource filters">
-  <!-- Clear all filters button - only visible when filters are active -->
+  
   <div class="clear-filters-wrapper" style="display: none;">
     <button id="clear-all-filters" class="clear-filters-btn" aria-label="Clear all active filters">
       Clear all filters
@@ -19,7 +19,7 @@ title: All
   </div>
   
   <article class="resourcenav resourcenavtopicknown">
-    <h2 id="topic-heading">Topic</h2>
+    <h2 id="topic-heading-known">Topic</h2>
     <p>
       <input
         type="checkbox"
@@ -35,8 +35,8 @@ title: All
   </article>
 
   <article class="resourcenav resourcenavtopicunknown topic-list">
-    <h2 id="topic-heading">Topic</h2>
-    <ul role="group" aria-labelledby="topic-heading">
+    <h2 id="topic-heading-unknown">Topic</h2>
+    <ul role="group" aria-labelledby="topic-heading-unknown">
       {% for topic in site.data.topics %}
       <li>
         <input
@@ -52,7 +52,7 @@ title: All
   
 
   <article class="resourcenav resourcenavmediumknown">
-    <h2 id="medium-heading">Medium</h2>
+    <h2 id="medium-heading-known">Medium</h2>
     <p>
       <input
         type="checkbox"
@@ -68,8 +68,8 @@ title: All
   </article>
 
   <article class="resourcenav resourcenavmediumunknown medium-list">
-    <h2 id="medium-heading">Medium</h2>
-    <ul role="group" aria-labelledby="medium-heading">
+    <h2 id="medium-heading-unknown">Medium</h2>
+    <ul role="group" aria-labelledby="medium-heading-unknown">
       {% for medium in site.data.media %}
       <li>
         <input
@@ -84,7 +84,7 @@ title: All
   </article>
 
   <article class="resourcenav resourcenavlanguageknown">
-    <h2 id="language-heading">Language</h2>
+    <h2 id="language-heading-known">Language</h2>
     <p>
       <input
         type="checkbox"
@@ -101,8 +101,8 @@ title: All
   </article>
 
   <article class="resourcenav resourcenavlanguageunknown language-list">
-    <h2 id="language-heading">Language</h2>
-    <ul role="group" aria-labelledby="language-heading">
+    <h2 id="language-heading-unknown">Language</h2>
+    <ul role="group" aria-labelledby="language-heading-unknown">
       {% for language in site.data.languages %}
       <li>
         <input


### PR DESCRIPTION
## Fixes
- Fixes #192 by @possumbilities

## Description
Enhanced category filter accessibility with ARIA labels, keyboard navigation support, focus indicators, and a "Clear all filters" button for improved screen reader and keyboard user experience.

## Technical details
Added semantic ARIA roles and labels to filter sections, implemented CSS focus styles with high-contrast outlines, and created an accessible clear filters button with keyboard event handlers in listing.js.

## Tests
1. Navigate to http://localhost:4000/all/
2. Use Tab key to navigate through filter checkboxes and verify visible focus indicators
3. Select filters using Space/Enter keys and verify the "Clear all filters" button appears
4. Test button with keyboard (Enter/Space) to clear all filters

## Screenshots
<!-- User can add before/after screenshots showing focus indicators and clear button -->

## Checklist
- [x] I have read and understood the Developer Certificate of Origin (DCO), below, which covers the contents of this pull request (PR).
- [x] My pull request doesn't include code or content generated with AI.
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated unit tests and/or test scripts for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.


[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
